### PR TITLE
Bump cibuildwheel and fix macos build

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -18,25 +18,26 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-14, macos-13]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.19.2
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: pyminiply-wheels-${{ matrix.os }}
           path: ./wheelhouse/*.whl
 
   build_sdist:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -52,10 +53,11 @@ jobs:
         run: |
           pip install dist/*
           pip install pytest pyvista
-          pytest -x
+          pytest
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: pyminiply-sdist
           path: dist/*.tar.gz
 
   upload_pypi:
@@ -63,22 +65,25 @@ jobs:
     runs-on: ubuntu-latest
     # upload to PyPI on every tag
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-    # alternatively, to publish when a GitHub Release is created, use the following rule:
-    # if: github.event_name == 'release' && github.event.action == 'published'
     steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: artifact
-          path: dist
+    - uses: actions/download-artifact@v4
+    - name: Flatten directory structure
+      run: |
+        mkdir -p dist/
+        find . -name '*.whl' -exec mv {} dist/ \;
+        find . -name '*.tar.gz' -exec mv {} dist/ \;
 
-      - uses: pypa/gh-action-pypi-publish@v1.8.6
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
+    - name: List artifacts
+      run: ls -R
 
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        with:
-          generate_release_notes: true
-          files: |
-            ./dist/*.whl
+    - uses: pypa/gh-action-pypi-publish@v1.9.0
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_TOKEN }}
+
+    - name: Release
+      uses: softprops/action-gh-release@v2
+      with:
+        generate_release_notes: true
+        files: |
+          ./dist/*.whl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,10 @@ test-requires = "pytest pyvista"
 test-command = "pytest {project}/tests"
 
 [tool.cibuildwheel.macos]
-# https://cibuildwheel.readthedocs.io/en/stable/faq/#apple-silicon
-archs = ["x86_64", "universal2"]
-test-skip = ["*_arm64", "*_universal2:arm64"]
+archs = ["native"]
+
+[tool.cibuildwheel.macos.environment]
+MACOSX_DEPLOYMENT_TARGET = "10.14"  # Needed for full C++17 support on MacOS
 
 [tool.codespell]
 skip = '*.cxx,*.h,*.gif,*.png,*.jpg,*.js,*.html,*.doctree,*.ttf,*.woff,*.woff2,*.eot,*.mp4,*.inv,*.pickle,*.ipynb,flycheck*,./.git/*,./.hypothesis/*,*.yml,./doc/build/*,./doc/images/*,./dist/*,*~,.hypothesis*,*.cpp,*.c'

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 """Setup for pyminiply."""
+
 from io import open as io_open
 import os
 import sys
@@ -80,5 +81,5 @@ setup(
         "pyminiply/wrapper": ["*.c", "*.h"],
     },
     keywords="read ply",
-    install_requires=["numpy>1.11.0"],
+    install_requires=["numpy>1.11.0,<2.0"],
 )


### PR DESCRIPTION
Fix build by updating cibuildwheel and building on MacOS natively.

Temporarily limit to `numpy<2.0`, pending building with nanobind.