### PR TITLE
Support point clouds

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "src/miniply"]
 	path = src/miniply
-	url = https://github.com/vilya/miniply
+	url = https://github.com/akaszynski/miniply
+	branch = patch-1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,13 @@ repos:
     additional_dependencies: [tomli==2.0.1]
     files: ^src/pyminiply/.*\.py
 
+
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v1.13.0
+  hooks:
+  - id: mypy
+    additional_dependencies: [numpy>=2.0]
+
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v5.0.0
   hooks:
@@ -45,6 +52,7 @@ repos:
     args: [--autofix]
   - id: pretty-format-yaml
     args: [--autofix, --indent, '2']
+
 
 - repo: https://github.com/pre-commit/mirrors-clang-format
   rev: v19.1.6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ ci:
 
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.8.6
+  rev: v0.11.2
   hooks:
   - id: ruff
     args: [--fix, --exit-non-zero-on-fix]
@@ -19,7 +19,7 @@ repos:
     exclude: README.rst
 
 - repo: https://github.com/codespell-project/codespell
-  rev: v2.3.0
+  rev: v2.4.1
   hooks:
   - id: codespell
     args: [--skip=*.vt*]
@@ -33,10 +33,10 @@ repos:
 
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.13.0
+  rev: v1.15.0
   hooks:
   - id: mypy
-    additional_dependencies: [numpy>=2.0]
+    additional_dependencies: [numpy>=2.0, pytest-stub]
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v5.0.0
@@ -55,12 +55,12 @@ repos:
 
 
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v19.1.6
+  rev: v20.1.0
   hooks:
   - id: clang-format
 
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.30.0
+  rev: 0.31.3
   hooks:
   - id: check-github-workflows
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,11 +11,23 @@ If using emacs and helm, generate the project configuration files using `-DCMAKE
 ```
 pip install nanobind
 export NANOBIND_INCLUDE=$(python -c "import nanobind, os; print(os.path.join(os.path.dirname(nanobind.__file__), 'cmake'))")
-cmake -Dnanobind_DIR=$NANOBIND_INCLUDE -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES="/usr/include/c++/11;/usr/include/x86_64-linux-gnu/c++/11/;/usr/lib/gcc/x86_64-linux-gnu/11/include/"
+cmake -Dnanobind_DIR=$NANOBIND_INCLUDE -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES="/usr/include/c++/13;/usr/include/x86_64-linux-gnu/c++/13/;/usr/lib/gcc/x86_64-linux-gnu/13/include/"
 ```
 
 These will be necessary for helm and treesit to determine the locations of the header files.
 
+
+Note: C++ include directory might have to be modified depending on which version you have installed. Check with:
+
+```bash
+ls /usr/include/c++
+```
+
+Also, Make sure you have ``clangd`` installed:
+
+```bash
+sudo apt install clangd
+```
 
 #### Debug Build
 
@@ -55,3 +67,17 @@ These can be challenging to find. Use [valgrind](https://valgrind.org/) with the
 ```
  valgrind --leak-check=full --log-file=val.txt --suppressions=valgrind-python.supp pytest -k clus && grep 'new\[\]' val.txt
  ```
+
+#### Fast builds
+
+For faster builds, run without build isolation with:
+
+```
+pip install -e . --no-build-isolation 
+```
+
+Dependencies:
+```
+pip install nanobind
+sudo apt install ninja-build
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ These can be challenging to find. Use [valgrind](https://valgrind.org/) with the
 For faster builds, run without build isolation with:
 
 ```
-pip install -e . --no-build-isolation 
+pip install -e . --no-build-isolation
 ```
 
 Dependencies:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,10 @@ MACOSX_DEPLOYMENT_TARGET = "10.14"  # Needed for full C++17 support on MacOS
 quiet-level = 3
 skip = '*.cxx,*.h,*.gif,*.png,*.jpg,*.js,*.html,*.doctree,*.ttf,*.woff,*.woff2,*.eot,*.mp4,*.inv,*.pickle,*.ipynb,flycheck*,./.git/*,./.hypothesis/*,*.yml,./doc/build/*,./doc/images/*,./dist/*,*~,.hypothesis*,*.cpp,*.c'
 
+[tool.mypy]
+plugins = ["numpy.typing.mypy_plugin"]
+strict = true
+
 [tool.pytest.ini_options]
 filterwarnings = [
   # bogus numpy ABI warning (see numpy/#432)
@@ -58,10 +62,6 @@ line-length = 100
 
 [tool.ruff.lint]
 extend-select = ["I"]
-
-[tool.mypy]
-plugins = ["numpy.typing.mypy_plugin"]
-strict = true
 
 [tool.scikit-build]
 # Setuptools-style build caching in a local directory

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
 description = "Rapidly read in PLY files using a wrapper over miniply"
 name = "pyminiply"
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 version = "0.3.dev0"
 
 [project.optional-dependencies]
@@ -58,6 +58,10 @@ line-length = 100
 
 [tool.ruff.lint]
 extend-select = ["I"]
+
+[tool.mypy]
+plugins = ["numpy.typing.mypy_plugin"]
+strict = true
 
 [tool.scikit-build]
 # Setuptools-style build caching in a local directory

--- a/src/pyminiply/_wrapper.pyi
+++ b/src/pyminiply/_wrapper.pyi
@@ -1,0 +1,15 @@
+import numpy as np
+from numpy.typing import NDArray
+
+def load_ply(
+    filename: str,
+    read_normals: bool = True,
+    read_uv: bool = True,
+    read_color: bool = True,
+) -> tuple[
+    NDArray[np.float32],
+    NDArray[np.int32],
+    NDArray[np.float32],
+    NDArray[np.float32],
+    NDArray[np.uint8],
+]: ...

--- a/src/pyminiply/py.typed
+++ b/src/pyminiply/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/src/pyminiply/reader.py
+++ b/src/pyminiply/reader.py
@@ -1,8 +1,8 @@
 """Python wrapper of the miniply library."""
 
-from typing import Union, TYPE_CHECKING
-from pathlib import Path
 import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Union
 
 import numpy as np
 from numpy.typing import NDArray
@@ -10,10 +10,10 @@ from numpy.typing import NDArray
 from pyminiply._wrapper import load_ply
 
 if TYPE_CHECKING:
-    from pyvista.core import PolyData, PointSet
+    from pyvista.core.pointset import PointSet, PolyData
 
 
-def _polydata_from_faces(points: NDArray[np.float32], faces: NDArray[np.int32]):
+def _polydata_from_faces(points: NDArray[np.float32], faces: NDArray[np.int32]) -> "PolyData":
     """Generate a polydata from a faces array containing no padding and all triangles.
 
     This is a more efficient way of instantiating PolyData from point and face
@@ -28,7 +28,7 @@ def _polydata_from_faces(points: NDArray[np.float32], faces: NDArray[np.int32]):
 
     """
     try:
-        import pyvista as pv
+        from pyvista.core.pointset import PolyData
     except ModuleNotFoundError:
         raise ModuleNotFoundError(
             "To use this functionality, install PyVista with\n\npip install pyvista"
@@ -36,7 +36,7 @@ def _polydata_from_faces(points: NDArray[np.float32], faces: NDArray[np.int32]):
 
     from pyvista import ID_TYPE
 
-    # backwards compatability
+    # backwards compatibility
     try:
         from pyvista.core.utilities import numpy_to_idarr
     except ModuleNotFoundError:  # pragma: no cover
@@ -46,12 +46,12 @@ def _polydata_from_faces(points: NDArray[np.float32], faces: NDArray[np.int32]):
     if faces.ndim != 2:
         raise ValueError("Expected a two dimensional face array.")
 
-    pdata = pv.PolyData()
-    pdata.points = points  # type: ignore
+    pdata = PolyData()
+    pdata.points = points
 
     carr = vtkCellArray()
     offset = np.arange(0, faces.size + 1, faces.shape[1], dtype=ID_TYPE)
-    carr.SetData(numpy_to_idarr(offset, deep=True), numpy_to_idarr(faces, deep=True))  # type: ignore
+    carr.SetData(numpy_to_idarr(offset, deep=True), numpy_to_idarr(faces, deep=True))
     pdata.SetPolys(carr)
     return pdata
 

--- a/src/pyminiply/reader.py
+++ b/src/pyminiply/reader.py
@@ -1,13 +1,19 @@
 """Python wrapper of the miniply library."""
 
+from typing import Union, TYPE_CHECKING
+from pathlib import Path
 import os
 
 import numpy as np
+from numpy.typing import NDArray
 
 from pyminiply._wrapper import load_ply
 
+if TYPE_CHECKING:
+    from pyvista.core import PolyData, PointSet
 
-def _polydata_from_faces(points, faces):
+
+def _polydata_from_faces(points: NDArray[np.float32], faces: NDArray[np.int32]):
     """Generate a polydata from a faces array containing no padding and all triangles.
 
     This is a more efficient way of instantiating PolyData from point and face
@@ -30,31 +36,43 @@ def _polydata_from_faces(points, faces):
 
     from pyvista import ID_TYPE
 
+    # backwards compatability
     try:
         from pyvista.core.utilities import numpy_to_idarr
     except ModuleNotFoundError:  # pragma: no cover
-        from pyvista.utilities.cells import numpy_to_idarr
+        from pyvista.utilities.cells import numpy_to_idarr  # try: ignore
     from vtkmodules.vtkCommonDataModel import vtkCellArray
 
     if faces.ndim != 2:
         raise ValueError("Expected a two dimensional face array.")
 
     pdata = pv.PolyData()
-    pdata.points = points
+    pdata.points = points  # type: ignore
 
     carr = vtkCellArray()
     offset = np.arange(0, faces.size + 1, faces.shape[1], dtype=ID_TYPE)
-    carr.SetData(numpy_to_idarr(offset, deep=True), numpy_to_idarr(faces, deep=True))
+    carr.SetData(numpy_to_idarr(offset, deep=True), numpy_to_idarr(faces, deep=True))  # type: ignore
     pdata.SetPolys(carr)
     return pdata
 
 
-def read(filename, read_normals=True, read_uv=True, read_color=True):
+def read(
+    filename: Union[str, Path],
+    read_normals: bool = True,
+    read_uv: bool = True,
+    read_color: bool = True,
+) -> tuple[
+    NDArray[np.float32],
+    NDArray[np.int32],
+    NDArray[np.float32],
+    NDArray[np.float32],
+    NDArray[np.uint8],
+]:
     """Read a PLY file and extract vertices, indices, normals, UV, and color information.
 
     Parameters
     ----------
-    filename : str
+    filename : str | Path
         The path to the PLY file.
     read_normals : bool, default: True
         If ``True``, the normals are read from the PLY file.
@@ -73,7 +91,7 @@ def read(filename, read_normals=True, read_uv=True, read_color=True):
     indices : numpy.ndarray[int32]
         An array of triangle indices from the PLY file. Each row represents a
         triangle, and the columns represent the indices of the vertices that
-        make up the triangle.
+        make up the triangle. This array may be empty if there are no vertices.
     normals : numpy.ndarray[float32]
         An array of vertex normals from the PLY file, if `read_normals` is
         True.  Each row represents a normal, and the columns represent the X,
@@ -142,14 +160,20 @@ def read(filename, read_normals=True, read_uv=True, read_color=True):
            [255, 255, 255]], dtype=uint8)
 
     """
+    filename = str(filename)
     if not os.path.isfile(filename):
         raise FileNotFoundError(f'Invalid file or unable to locate "{filename}"')
     return load_ply(filename, read_normals, read_uv, read_color)
 
 
-def read_as_mesh(filename, read_normals=True, read_uv=True, read_color=True):
+def read_as_mesh(
+    filename: Union[str, Path],
+    read_normals: bool = True,
+    read_uv: bool = True,
+    read_color: bool = True,
+) -> Union["PointSet", "PolyData"]:
     """
-    Read a binary STL file and return it as a PyVista mesh.
+    Read a binary STL file and return it as a PyVista PolyData or PointSet.
 
     This function uses the `get_stl_data` function, which is a wrapper
     of https://github.com/aki5/libstl, to read STL files.
@@ -168,8 +192,8 @@ def read_as_mesh(filename, read_normals=True, read_uv=True, read_color=True):
 
     Returns
     -------
-    mesh : pyvista.PolyData
-        The mesh from the STL file, represented as a PyVista PolyData object.
+    pyvista.PolyData | PointSet
+        The mesh from the PLY file, represented as a PyVista PolyData or PointSet.
 
     Raises
     ------
@@ -198,7 +222,17 @@ def read_as_mesh(filename, read_normals=True, read_uv=True, read_color=True):
 
     """
     vertices, indices, normals, uv, color = read(filename, read_normals, read_uv, read_color)
-    mesh = _polydata_from_faces(vertices, indices)
+    if vertices is None:
+        raise RuntimeError("PLY file is missing vertices")
+
+    if indices is None or not indices.size:
+        # handle point clouds
+        from pyvista.core import PointSet
+
+        mesh = PointSet(vertices)
+    else:
+        mesh = _polydata_from_faces(vertices, indices)
+
     if read_normals and normals.size:
         mesh.point_data["Normals"] = normals
     if read_uv and uv.size:

--- a/src/wrapper.cpp
+++ b/src/wrapper.cpp
@@ -36,7 +36,7 @@ nb::tuple LoadPLY(const std::string &filename, bool read_normals = true,
   NDArray<float, 2> uv = MakeNDArray<float, 2>({0, 2});
   NDArray<uint8_t, 2> color = MakeNDArray<uint8_t, 2>({0, 3});
 
-  while (reader.has_element() && (!gotVerts || !gotFaces)) {
+  while (reader.has_element() && (!gotVerts || !gotFaces)) {      
     if (reader.element_is(miniply::kPLYVertexElement) &&
         reader.load_element() && reader.find_pos(indexes)) {
       numVerts = reader.num_rows();
@@ -94,13 +94,13 @@ nb::tuple LoadPLY(const std::string &filename, bool read_normals = true,
     reader.next_element();
   }
 
-  if (!gotVerts) {
-    throw std::runtime_error("Failed to load vertices");
-  }
+  // if (!gotVerts) {
+  //   throw std::runtime_error("Failed to load vertices");
+  // }
 
-  if (!gotFaces) {
-    throw std::runtime_error("Failed to load faces");
-  }
+  // if (!gotFaces) {
+  //   throw std::runtime_error("Failed to load faces");
+  // }
 
   return nb::make_tuple(pos, indices, normals, uv, color);
 }

--- a/src/wrapper.cpp
+++ b/src/wrapper.cpp
@@ -36,7 +36,7 @@ nb::tuple LoadPLY(const std::string &filename, bool read_normals = true,
   NDArray<float, 2> uv = MakeNDArray<float, 2>({0, 2});
   NDArray<uint8_t, 2> color = MakeNDArray<uint8_t, 2>({0, 3});
 
-  while (reader.has_element() && (!gotVerts || !gotFaces)) {      
+  while (reader.has_element() && (!gotVerts || !gotFaces)) {
     if (reader.element_is(miniply::kPLYVertexElement) &&
         reader.load_element() && reader.find_pos(indexes)) {
       numVerts = reader.num_rows();

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -6,7 +6,7 @@ import numpy as np
 import pyminiply
 import pytest
 import pyvista as pv
-from pyvista.core import PointSet
+from pyvista.core.pointset import PointSet
 
 
 @pytest.fixture

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1,14 +1,17 @@
 """Test pyminiply."""
 
+from pathlib import Path
+
 import numpy as np
 import pyminiply
 import pytest
 import pyvista as pv
+from pyvista.core import PointSet
 
 
 @pytest.fixture
-def plyfile(tmpdir):
-    filename = tmpdir.join("tmp.ply")
+def plyfile(tmp_path: Path) -> str:
+    filename = tmp_path / "tmp.ply"
     mesh = pv.Plane().triangulate().subdivide(2)
     mesh["RGB"] = np.vstack([np.linspace(0, 255, mesh.n_points, dtype=np.uint8)] * 3).T
     mesh.save(filename, texture="RGB")
@@ -16,18 +19,28 @@ def plyfile(tmpdir):
 
 
 @pytest.fixture
-def plyfile_ascii(tmpdir):
-    filename = tmpdir.join("tmp.ply")
+def plyfile_point_cloud(tmp_path: Path) -> str:
+    filename = tmp_path / "tmp.ply"
+    mesh = pv.Plane().triangulate().subdivide(2)
+    mesh["RGB"] = np.vstack([np.linspace(0, 255, mesh.n_points, dtype=np.uint8)] * 3).T
+    mesh.faces = np.empty(0, np.int32)
+    mesh.save(filename, texture="RGB")
+    return str(filename)
+
+
+@pytest.fixture
+def plyfile_ascii(tmp_path: Path) -> str:
+    filename = tmp_path / "tmp.ply"
     mesh = pv.Plane().triangulate()
     mesh["RGB"] = np.vstack([np.linspace(0, 255, 121, dtype=np.uint8)] * 3).T
     mesh.save(filename, texture="RGB", binary=False)
     return str(filename)
 
 
-def test_read_binary(plyfile):
+def test_read_binary(plyfile: str) -> None:
     pv_mesh = pv.read(plyfile)
 
-    points, ind, normals, uv, color = pyminiply.read(plyfile)
+    points, ind, normals, uv, color = pyminiply.read(Path(plyfile))
     assert np.allclose(pv_mesh.points, points)
     assert np.allclose(pv_mesh._connectivity_array, ind.ravel())
     assert np.allclose(pv_mesh["Normals"], normals)
@@ -35,7 +48,7 @@ def test_read_binary(plyfile):
     assert np.allclose(pv_mesh["RGB"], color)
 
 
-def test_read_ascii(plyfile_ascii):
+def test_read_ascii(plyfile_ascii: str) -> None:
     pv_mesh = pv.read(plyfile_ascii)
 
     points, ind, normals, uv, color = pyminiply.read(plyfile_ascii)
@@ -46,7 +59,7 @@ def test_read_ascii(plyfile_ascii):
     assert np.allclose(pv_mesh["RGB"], color)
 
 
-def test_read_as_mesh(plyfile):
+def test_read_as_mesh(plyfile: str) -> None:
     pv_mesh = pv.read(plyfile)
 
     ply_mesh = pyminiply.read_as_mesh(plyfile)
@@ -57,4 +70,18 @@ def test_read_as_mesh(plyfile):
     assert np.allclose(pv_mesh._connectivity_array, ply_mesh._connectivity_array)
 
     ply_mesh = pyminiply.read_as_mesh(plyfile, read_normals=False)
-    assert ["Normals"] not in ply_mesh.point_data
+    assert "Normals" not in ply_mesh.point_data
+
+
+def test_read_as_mesh_point_cloud(plyfile_point_cloud: str) -> None:
+    pv_mesh = pv.read(plyfile_point_cloud)
+
+    ply_mesh = pyminiply.read_as_mesh(Path(plyfile_point_cloud))
+    assert isinstance(ply_mesh, PointSet)
+    assert np.allclose(pv_mesh["Normals"], ply_mesh["Normals"])
+    assert np.allclose(pv_mesh["TCoords"], ply_mesh["TCoords"])
+    assert np.allclose(pv_mesh["RGB"], ply_mesh["RGB"])
+    assert np.allclose(pv_mesh.points, ply_mesh.points)
+
+    ply_mesh = pyminiply.read_as_mesh(plyfile_point_cloud, read_normals=False)
+    assert "Normals" not in ply_mesh.point_data


### PR DESCRIPTION
Provide support for point clouds to resolve #13.

Testing shows ~4x improvement over vtk's `vtkPLYReader` used in `pyvista`:

```py
>>> timeit pyminiply.read("plane_bin.ply")
28.7 ms ± 166 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)

>>> timeit pyminiply.read_as_mesh("plane_bin.ply")
29.6 ms ± 105 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)

>>> timeit pv.read("plane_bin.ply")
129 ms ± 1.62 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```