### PR TITLE
Use int32

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,9 +5,9 @@ ci:
 
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.11.4
+  rev: v0.11.12
   hooks:
-  - id: ruff
+  - id: ruff-check
     args: [--fix, --exit-non-zero-on-fix]
     exclude: ^(docs/|tests)
   - id: ruff-format
@@ -33,7 +33,7 @@ repos:
 
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.15.0
+  rev: v1.16.0
   hooks:
   - id: mypy
     additional_dependencies: [numpy>=2.0, pytest-stub]
@@ -55,12 +55,12 @@ repos:
 
 
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v20.1.0
+  rev: v20.1.5
   hooks:
   - id: clang-format
 
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.32.1
+  rev: 0.33.0
   hooks:
   - id: check-github-workflows
 

--- a/src/pyminiply/reader.py
+++ b/src/pyminiply/reader.py
@@ -41,6 +41,10 @@ def _polydata_from_faces(points: NDArray[np.float32], faces: NDArray[np.int32]) 
     if faces.ndim != 2:
         raise ValueError("Expected a two dimensional face array.")
 
+    # while faces might be correctly sized, the required offset might exceed np.int32
+    if faces.size >= np.iinfo(np.int32).max:
+        faces = faces.astype(np.int64)
+
     if faces.dtype == np.int32:
         vtk_dtype = vtkTypeInt32Array().GetDataType()
     elif faces.dtype == np.int64:


### PR DESCRIPTION
Two performance improvements:
- Use int32 by default for both the offset and faces array.
- Don't copy arrays when creating `vtkCellArray`, but keep the references by monkey patching `vtkCellArray`. Same approach VTK uses internally.

Locally, improves `read_as_mesh` performance from around 1.0 seconds on a 500 MB file from:
```
>>> timeit pyminiply.read_as_mesh('rotor.ply')
1 s ± 7.86 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

To around 669 ms:

```py
>>> timeit pyminiply.read_as_mesh('rotor.ply')
669 ms ± 7.99 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
