### PR TITLE
Use fixed-size storage for PLY triangles

### DIFF
--- a/src/pyvista_miniply/reader.py
+++ b/src/pyvista_miniply/reader.py
@@ -36,6 +36,7 @@ def _polydata_from_faces(points: NDArray[np.float32], faces: NDArray[np.int32]) 
 
     """
     try:
+        from pyvista import vtk_version_info
         from pyvista.core.pointset import PolyData
     except ModuleNotFoundError:
         raise ModuleNotFoundError(
@@ -61,14 +62,17 @@ def _polydata_from_faces(points: NDArray[np.float32], faces: NDArray[np.int32]) 
         raise TypeError(f"Unsupported dtype ({type(faces)} for faces. Expected int32 or int64.")
 
     # convert to vtk arrays without copying
-    offset = np.arange(0, faces.size + 1, faces.shape[1], dtype=faces.dtype)
-    offset_vtk = numpy_to_vtk(offset, deep=False, array_type=vtk_dtype)
     faces_vtk = numpy_to_vtk(faces.ravel(), deep=False, array_type=vtk_dtype)
 
     # create the vtk arrays and keep references to avoid gc
     carr = vtkCellArray()
-    carr.SetData(offset_vtk, faces_vtk)
-    carr._offset_np_ref = offset_vtk
+    if vtk_version_info >= (9, 6, 2):
+        carr.SetData(faces.shape[1], faces_vtk)
+    else:
+        offset = np.arange(0, faces.size + 1, faces.shape[1], dtype=faces.dtype)
+        offset_vtk = numpy_to_vtk(offset, deep=False, array_type=vtk_dtype)
+        carr.SetData(offset_vtk, faces_vtk)
+        carr._offset_np_ref = offset_vtk
     carr._faces_np_ref = faces_vtk
 
     pdata = PolyData()

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -74,6 +74,8 @@ def test_read_as_mesh(plyfile: str) -> None:
     assert np.allclose(pv_mesh["RGB"], ply_mesh["RGB"])
     assert np.allclose(pv_mesh.points, ply_mesh.points)
     assert np.allclose(pv_mesh._connectivity_array, ply_mesh._connectivity_array)
+    if pv.vtk_version_info >= (9, 6, 2):
+        assert ply_mesh.GetPolys().IsStorageFixedSize()
 
     ply_mesh = pyvista_miniply.read_as_mesh(plyfile, read_normals=False)
     assert "Normals" not in ply_mesh.point_data


### PR DESCRIPTION
## Summary

Use VTK's fixed-size cell storage for miniply's triangle connectivity on VTK 9.6.2 and newer. Miniply triangulates polygonal input faces before returning them, so every non-point-cloud result has a constant cell width of three. The fixed representation keeps offsets implicit and removes one `int32` offset allocation per triangle.

Older VTK versions retain the existing explicit-offset path, selected with `pyvista.vtk_version_info`.

## Benchmarks

Intel Xeon E-2288G, Python 3.12.12, NumPy 2.5.1, PyVista 0.48.4, and VTK 9.6.2. Each result is the median of 21 paired samples on one pinned CPU core, with execution order alternated after five warmup runs.

| Triangles | Explicit offsets | Fixed size | Speedup | Offset allocation removed |
| ---: | ---: | ---: | ---: | ---: |
| 100,000 | 355.70 us | 282.37 us | 1.26x | 0.40 MB |
| 1,000,000 | 1,246.83 us | 294.92 us | 4.23x | 4.00 MB |

<details>
<summary>Benchmark script</summary>

```python
"""Compare generic-offset and fixed-size vtkCellArray construction."""

import gc
import platform
import statistics
import sys
import time

import numpy as np
import pyvista as pv
from pyvista.core.pointset import PolyData
from pyvista_miniply.reader import _polydata_from_faces
from vtkmodules.util.numpy_support import numpy_to_vtk
from vtkmodules.vtkCommonCore import vtkTypeInt32Array
from vtkmodules.vtkCommonDataModel import vtkCellArray


def build_with_offsets(points: np.ndarray, faces: np.ndarray) -> PolyData:
    """Build polydata using an explicit offset array."""
    vtk_dtype = vtkTypeInt32Array().GetDataType()
    offsets = np.arange(0, faces.size + 1, faces.shape[1], dtype=faces.dtype)
    offsets_vtk = numpy_to_vtk(offsets, deep=False, array_type=vtk_dtype)
    faces_vtk = numpy_to_vtk(faces.ravel(), deep=False, array_type=vtk_dtype)
    cells = vtkCellArray()
    cells.SetData(offsets_vtk, faces_vtk)
    cells._offset_np_ref = offsets_vtk
    cells._faces_np_ref = faces_vtk
    mesh = PolyData()
    mesh.points = points
    mesh.SetPolys(cells)
    return mesh


def time_once(function, points: np.ndarray, faces: np.ndarray) -> int:
    """Return one construction time in nanoseconds."""
    start = time.perf_counter_ns()
    mesh = function(points, faces)
    elapsed = time.perf_counter_ns() - start
    del mesh
    gc.collect()
    return elapsed


print(platform.platform())
print(sys.version.split()[0], f"NumPy {np.__version__}", f"PyVista {pv.__version__}")
print(f"VTK {pv.vtk_version_info.major}.{pv.vtk_version_info.minor}.{pv.vtk_version_info.micro}")

for n_cells in (100_000, 1_000_000):
    points = np.zeros((3, 3), dtype=np.float32)
    faces = np.zeros((n_cells, 3), dtype=np.int32)

    for _ in range(5):
        time_once(build_with_offsets, points, faces)
        time_once(_polydata_from_faces, points, faces)

    offset_times: list[int] = []
    fixed_times: list[int] = []
    for sample in range(21):
        order = (
            (build_with_offsets, offset_times),
            (_polydata_from_faces, fixed_times),
        )
        if sample % 2:
            order = order[::-1]
        for function, values in order:
            values.append(time_once(function, points, faces))

    offset_us = statistics.median(offset_times) / 1_000
    fixed_us = statistics.median(fixed_times) / 1_000
    saved_mb = 4 * (n_cells + 1) / 1_000_000
    print(
        f"{n_cells:,} triangles: offsets={offset_us:.2f} us, "
        f"fixed={fixed_us:.2f} us, speedup={offset_us / fixed_us:.2f}x, "
        f"offset allocation removed={saved_mb:.2f} MB"
    )
```

</details>

## AI Attribution

Used ChatGPT's [GPT-5.6](https://openai.com/index/gpt-5-6/).
