### PR TITLE
Resolve VTK through PyVista so the cvista fork is usable

### DIFF
--- a/src/pyvista_miniply/reader.py
+++ b/src/pyvista_miniply/reader.py
@@ -37,15 +37,17 @@ def _polydata_from_faces(points: NDArray[np.float32], faces: NDArray[np.int32]) 
     """
     try:
         from pyvista import vtk_version_info
+        from pyvista._vtk import (
+            numpy_to_vtk,
+            vtkCellArray,
+            vtkTypeInt32Array,
+            vtkTypeInt64Array,
+        )
         from pyvista.core.pointset import PolyData
     except ModuleNotFoundError:
         raise ModuleNotFoundError(
             "To use this functionality, install PyVista with\n\npip install pyvista"
         )
-
-    from vtkmodules.util.numpy_support import numpy_to_vtk as numpy_to_vtk
-    from vtkmodules.vtkCommonCore import vtkTypeInt32Array, vtkTypeInt64Array
-    from vtkmodules.vtkCommonDataModel import vtkCellArray
 
     if faces.ndim != 2:
         raise ValueError("Expected a two dimensional face array.")


### PR DESCRIPTION
Importing `vtkmodules` directly loads stock VTK regardless of which build PyVista selected. With PyVista on the `cvista` fork that puts two copies of VTK in the process, and they do not share types, so the cell array this module builds cannot be attached to the polydata PyVista made:

```
TypeError: SetPolys argument 1
```

`numpy_to_vtk`, `vtkCellArray`, `vtkTypeInt32Array` and `vtkTypeInt64Array` now come from `pyvista._vtk`, which resolves against whichever build PyVista chose. They move inside the existing `try`/`except`, so a missing PyVista still raises the same pointed `ModuleNotFoundError`. `vtkmodules` no longer appears anywhere in the package.

## Results

| | stock VTK | cvista |
| --- | --- | --- |
| before | 8 passed | **read_as_mesh raises `TypeError: SetPolys argument 1`** |
| after | 8 passed | 8 passed |

Both columns run explicitly, via `PYVISTA_VTK_BACKEND=vtkmodules` and `=cvista`.

## Verified the objects, not just the imports

The failure mode is a type mismatch at a boundary, so "it imported" proves nothing. A read is checked to produce a mesh whose `vtkCellArray` and `vtkPoints` are the same classes `pyvista._vtk` resolves -- whatever PyVista resolves is by definition the right class, so the check needs no knowledge of which backend is in play:

```
pyvista_miniply  backend=cvista  cell array matches pyvista=Y  points match pyvista=Y
pyvista_miniply  backend=vtk     cell array matches pyvista=Y  points match pyvista=Y
```

with the geometry asserted equal to the source mesh in both cases.

Companion to pyvista/pyvista-stl#53, which needed the same change plus its test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
